### PR TITLE
Make user_id in threads table unsigned

### DIFF
--- a/database/migrations/2016_09_15_034736_create_threads_table.php
+++ b/database/migrations/2016_09_15_034736_create_threads_table.php
@@ -17,7 +17,7 @@ class CreateThreadsTable extends Migration
             $table->increments('id');
             $table->string('title');
             $table->text('body');
-            $table->integer('user_id');
+            $table->integer('user_id')->unsigned();
             $table->timestamps();
             $table->foreign('user_id')->references('id')->on('users');
         });


### PR DESCRIPTION
Make user_id in threads table unsigned so it matches user_id column in users table for mysql to create foreign key. This fixes the issue we ran into last time we were using mysql as a group.
